### PR TITLE
fix getLastRow() call for Atom 1.9

### DIFF
--- a/lib/slickedit-select.coffee
+++ b/lib/slickedit-select.coffee
@@ -82,8 +82,8 @@ module.exports =
       targetLeft       = pixelPosition.left
       defaultCharWidth = editorBuffer.defaultCharWidth
       row              = Math.floor(targetTop / editorBuffer.getLineHeightInPixels())
-      targetLeft       = Infinity if row > editorBuffer.getLastRow()
-      row              = Math.min(row, editorBuffer.getLastRow())
+      targetLeft       = Infinity if row > editor.buffer.getLastRow()
+      row              = Math.min(row, editor.buffer.getLastRow())
       row              = Math.max(0, row)
       column           = Math.round (targetLeft) / defaultCharWidth
       return {row: row, column: column}


### PR DESCRIPTION
taken from here: https://github.com/bigfive/atom-sublime-select/issues/97
fixes #3
